### PR TITLE
Examples with larger type face / sidebar layout

### DIFF
--- a/index-larger-type.html
+++ b/index-larger-type.html
@@ -12,31 +12,6 @@
   <style>
     :root {
       --base-font: 20px;
-      --gutter: 40px;
-    }
-    @media only screen and (min-width: 768px) {
-      .service-navigation--alt .service-navigation-level-2 li {
-        display: inline-block;
-        margin: 0;
-        padding: 0;
-      }
-      .service-navigation--alt .service-navigation-level-2 a {
-        display: inline-block;
-        padding-right: 20px;
-      }
-      .service-navigation--alt li.active {
-        background-color: unset;
-      }
-      .service-navigation--alt .service-navigation-level-2 a:after {
-        display: inline-block;
-        background-image: unset;
-        content: '/';
-        width: 15px;
-        text-align: center;
-      }
-      .service-navigation--alt .service-navigation-level-2 :last-child a:after {
-        content: '';
-      }
     }
   </style>
 </head>
@@ -64,45 +39,47 @@
       </ol>
     </div>
   </div>
-  <div class="wrapper wrapper--no-gutter">
-    <main>
-      <div class="row">
-        <section class="page-content col-md-8">
-          <h1 class="page-title">Ask for a repair to your council home</h1>
-          <div class="page-subtitle">Ask us to repair your council home if it’s been damaged.</div>
-          <p>Before you ask us for a repair, make sure who’s responsible as there are some repairs you’ll need to carry out yourself.</p>
-          <p>You can request a repair online or, if your council home needs an emergency repair, call us on 0800 052 6140.</p>
-          <p>If the repair is for a suspected gas leak, please call the National Grid on 0800 111 999.</p>
-          <p>Repairs, maintenance and improvement services for council housing are now run directly by the council. Download our quick guide to the new repairs and maintenance service.</p>
-          <h2>How long does a repair take?</h2>
-          <p>When you ask us for a repair, the time it takes for us to start the work depends on the type of repair.</p>
-          <p>We’ll decide if your repair is:</p>
-          <ul>
-            <li>emergency, which we’ll start within 24 hours</li>
-            <li>routine, which we’ll start within 20 workings days</li>
-            <li>complex, which will take longer than 20 days to complete</li>
-          </ul>
-          <p>You can read more about types of repairs in our housing repairs handbook.</p>
-        </section>
-        <section class="sidebar col-md-4">
-          <h2>Services</h2>
-          <ul class="unstyled-list">
-            <li><a class="btn btn-success btn-next" href="#">Request a repair</a></li>
-            <li><a class="btn btn-success btn-next" href="#">Request an update to an existing repair</a></li>
-            <li><a class="btn btn-success btn-next" href="#">Give us feedback on a repair</a></li>
-          </ul>
-          <h2>More information</h2>
-          <ul class="unstyled-list sidebar-links">
-            <li><a href="#">Repairs, maintenance and improvement services from April 2020</a></li>
-            <li><a href="#">Your new repairs, maintenance and improvement service</a></li>
-          </ul>
-        </section>
-      </div>
-    </main>
-    <div class="row">
-      <div class="aside col-sm-12">
-        <nav class="service-navigation service-navigation--alt">
-          <h2 class="service-navigation__title"><a href="#">Housing</a></h2>
+  <div class="wrapper">
+    <div class="row mobile-reverse">
+      <main class="col-sm-8 col-md-9">
+        <div class="row">
+          <section class="page-content col-md-8">
+            <h1 class="page-title">Ask for a repair to your council home</h1>
+            <div class="page-subtitle">Ask us to repair your council home if it’s been damaged.</div>
+            <p>Before you ask us for a repair, make sure who’s responsible as there are some repairs you’ll need to carry out yourself.</p>
+            <p>You can request a repair online or, if your council home needs an emergency repair, call us on 0800 052 6140.</p>
+            <p>If the repair is for a suspected gas leak, please call the National Grid on 0800 111 999.</p>
+            <p>Repairs, maintenance and improvement services for council housing are now run directly by the council. Download our quick guide to the new repairs and maintenance service.</p>
+            <h2>How long does a repair take?</h2>
+            <p>When you ask us for a repair, the time it takes for us to start the work depends on the type of repair.</p>
+            <p>We’ll decide if your repair is:</p>
+            <ul>
+              <li>emergency, which we’ll start within 24 hours</li>
+              <li>routine, which we’ll start within 20 workings days</li>
+              <li>complex, which will take longer than 20 days to complete</li>
+            </ul>
+            <p>You can read more about types of repairs in our housing repairs handbook.</p>
+          </section>
+          <section class="sidebar col-md-4">
+            <h2>Services</h2>
+            <ul class="unstyled-list">
+              <li><a class="btn btn-success btn-next" href="#">Request a repair</a></li>
+              <li><a class="btn btn-success btn-next" href="#">Request an update to an existing repair</a></li>
+              <li><a class="btn btn-success btn-next" href="#">Give us feedback on a repair</a></li>
+            </ul>
+            <h2>More information</h2>
+            <ul class="unstyled-list sidebar-links">
+              <li><a href="#">Repairs, maintenance and improvement services from April 2020</a></li>
+              <li><a href="#">Your new repairs, maintenance and improvement service</a></li>
+            </ul>
+          </section>
+        </div>
+      </main>
+      <div class="aside col-sm-4 col-md-3">
+        <nav class="service-navigation box">
+          <h2><a href="#">Home</a></h2>
+          <hr/>
+          <h3><a href="#">Housing</a></h3>
           <hr/>
           <ul class="service-navigation-level-1 unstyled-list">
             <li class="accordion-active">
@@ -185,6 +162,7 @@
         </nav>
       </div>
     </div>
+  </div>
   <script src="https://code.jquery.com/jquery-3.4.1.min.js" integrity="sha256-CSXorXvZcTkaix6Yvo6HppcZGetbYMGWSFlBw8HfCJo=" crossorigin="anonymous"></script>
   <script src="js/scripts.js"></script>
 </body>

--- a/index-one-sidebar--alt-service-nav.html
+++ b/index-one-sidebar--alt-service-nav.html
@@ -1,0 +1,190 @@
+<!DOCTYPE html>
+<!-- Deploys to https://awalbhc.github.io/bhcc-refresh/ -->
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Ask for a repair to your council home | Brighton & Hove City Council</title>
+  <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:100,400,400i,600,600i,700,700i,900,900i" rel="stylesheet">
+  <link rel="stylesheet" href="normalize.css">
+  <link rel="stylesheet" href="style.css">
+  <style>
+    :root {
+      --gutter: 40px;
+    }
+    @media only screen and (min-width: 768px) {
+      .service-navigation--alt .service-navigation-level-2 li {
+        display: inline-block;
+        margin: 0;
+        padding: 0;
+      }
+      .service-navigation--alt .service-navigation-level-2 a {
+        display: inline-block;
+        padding-right: 20px;
+      }
+      .service-navigation--alt li.active {
+        background-color: unset;
+      }
+      .service-navigation--alt .service-navigation-level-2 a:after {
+        display: inline-block;
+        background-image: unset;
+        content: '/';
+        width: 15px;
+        text-align: center;
+      }
+      .service-navigation--alt .service-navigation-level-2 :last-child a:after {
+        content: '';
+      }
+    }
+  </style>
+</head>
+<body>
+  <header class="header overlay-wrapper" style="background-image: url(img/housing.jpg)">
+    <div class="wrapper">
+      <div class="header-top">
+        <a href="#"><img src="img/brighton-and-hove-city-council-logo.png" class="bhcc-logo" alt=""></a>
+      </div>
+      <div class="header-content">
+        <div class="header-title">Council housing</div>
+        <div class="header-subtitle">Apply for council housing, pay your rent, request a repair or report a problem</div>
+      </div>
+    </div>
+    <div class="overlay"></div>
+  </header>
+  <div class="breadcrumb">
+    <div class="wrapper">
+      <span class="breadcrumb-prefix">You are here:</span>
+      <ol class="breadcrumbs inline-list">
+        <li><a href="#">Home</a></li>
+        <li><a href="#">Housing</a></li>
+        <li><a href="#">Council housing</a></li>
+        <li>Ask for a repair to your council home</li>
+      </ol>
+    </div>
+  </div>
+  <div class="wrapper wrapper--no-gutter">
+    <main>
+      <div class="row">
+        <section class="page-content col-md-8">
+          <h1 class="page-title">Ask for a repair to your council home</h1>
+          <div class="page-subtitle">Ask us to repair your council home if it’s been damaged.</div>
+          <p>Before you ask us for a repair, make sure who’s responsible as there are some repairs you’ll need to carry out yourself.</p>
+          <p>You can request a repair online or, if your council home needs an emergency repair, call us on 0800 052 6140.</p>
+          <p>If the repair is for a suspected gas leak, please call the National Grid on 0800 111 999.</p>
+          <p>Repairs, maintenance and improvement services for council housing are now run directly by the council. Download our quick guide to the new repairs and maintenance service.</p>
+          <h2>How long does a repair take?</h2>
+          <p>When you ask us for a repair, the time it takes for us to start the work depends on the type of repair.</p>
+          <p>We’ll decide if your repair is:</p>
+          <ul>
+            <li>emergency, which we’ll start within 24 hours</li>
+            <li>routine, which we’ll start within 20 workings days</li>
+            <li>complex, which will take longer than 20 days to complete</li>
+          </ul>
+          <p>You can read more about types of repairs in our housing repairs handbook.</p>
+        </section>
+        <section class="sidebar col-md-4">
+          <h2>Services</h2>
+          <ul class="unstyled-list">
+            <li><a class="btn btn-success btn-next" href="#">Request a repair</a></li>
+            <li><a class="btn btn-success btn-next" href="#">Request an update to an existing repair</a></li>
+            <li><a class="btn btn-success btn-next" href="#">Give us feedback on a repair</a></li>
+          </ul>
+          <h2>More information</h2>
+          <ul class="unstyled-list sidebar-links">
+            <li><a href="#">Repairs, maintenance and improvement services from April 2020</a></li>
+            <li><a href="#">Your new repairs, maintenance and improvement service</a></li>
+          </ul>
+        </section>
+      </div>
+    </main>
+    <div class="row">
+      <div class="aside col-sm-12">
+        <nav class="service-navigation service-navigation--alt">
+          <h2 class="service-navigation__title"><a href="#">Housing</a></h2>
+          <hr/>
+          <ul class="service-navigation-level-1 unstyled-list">
+            <li class="accordion-active">
+              <h4><a class="accordion-expand" href="#">Council housing</a></h4>
+              <ul class="service-navigation-level-2 unstyled-list sidebar-links">
+                <li><a href="#">Apply to join the housing register</a></li>
+                <li><a href="#">Make a bid on Homemove</a></li>
+                <li><a href="#">Move out of council housing</a></li>
+                <li><a href="#">Tell us about a change of occupants in your council home</a></li>
+                <li><a href="#">Apply to move to a different council property</a></li>
+                <li><a href="#">Swap your council or housing association home</a></li>
+                <li><a href="#">Apply for the Transfer Incentive Scheme</a></li>
+                <li class="active"><a href="#">Ask for a repair to your council home</a></li>
+                <li><a href="#">Make an improvement to your council home</a></li>
+                <li><a href="#">Changes to your home</a></li>
+                <li><a href="#">Get help with gardening at your council home</a></li>
+                <li><a href="#">Get help with decorating your council home</a></li>
+              </ul>
+              <hr/>
+            </li>
+            <li>
+              <h4><a class="accordion-expand" href="#">Private housing</a></h4>
+              <ul class="service-navigation-level-2 unstyled-list sidebar-links">
+                <li><a href="#">Carry out work on your home</a></li>
+                <li><a href="#">Contact us about your private rented housing</a></li>
+                <li><a href="#">Changes to your home</a></li>
+                <li><a href="#">How to find a home to rent</a></li>
+                <li><a href="#">Get help to keep up with your rent</a></li>
+                <li><a href="#">Get help to buy a home</a></li>
+                <li><a href="#">Join the register to build your own home</a></li>
+                <li><a href="#">Privately rented home condition survey</a></li>
+                <li><a href="#">Contact us about a property you're renting out</a></li>
+                <li><a href="#">Rent out your property through the council</a></li>
+                <li><a href="#">Houses in Multiple Occupation</a></li>
+                <li><a href="#"> Fire safety advice for landlords</a></li>
+              </ul>
+              <hr/>
+            </li>
+            <li>
+              <h4><a class="accordion-expand"  href="#">Homelessness and living on the street</a></h4>
+              <ul class="service-navigation-level-2 unstyled-list sidebar-links">
+                <li><a href="#">Get help if you're at risk of becoming homeless</a></li>
+                <li><a href="#">Get help to keep up with your rent</a></li>
+                <li><a href="#">Duty to refer for homelessness</a></li>
+                <li><a href="#">Get help if you're living on the street</a></li>
+                <li><a href="#">How to help people living on the street</a></li>
+                <li><a href="#">How we help rough sleepers in the city</a></li>
+                <li><a href="#">Get shelter during the cold weather</a></li>
+                <li><a href="#">Privacy notice for evaluation of support</a></li>
+              </ul>
+              <hr/>
+            </li>
+            <li>
+              <h4><a class="accordion-expand"  class="expand" href="#">Housing supply</a></h4>
+              <ul class="service-navigation-level-2 unstyled-list sidebar-links">
+                <li><a href="#">New homes for council neighbourhoods</a></li>
+                <li><a href="#">New affordable homes in the city</a></li>
+                <li><a href="#">Sell your property back to the council</a></li>
+                <li><a href="#">Develop a housing site in the city</a></li>
+              </ul>
+              <hr/>
+            </li>
+            <li>
+              <h4><a class="accordion-expand"  href="#">Travelling communities</a></h4>
+              <ul class="service-navigation-level-2 unstyled-list sidebar-links">
+                <li><a href="#">Contact our Traveller Liaison team</a></li>
+                <li><a href="#">St Michael's Way Traveller site</a></li>
+              </ul>
+              <hr/>
+            </li>
+            <li>
+              <h4><a class="accordion-expand"  href="#">Housing strategy and data</a></h4>
+              <ul class="service-navigation-level-2 unstyled-list sidebar-links">
+                <li><a href="#">Policies and strategies in general housing</a></li>
+                <li><a href="#">Annual report to council tenants and leaseholders</a></li>
+              </ul>
+              <hr/>
+            </li>
+          </ul>
+        </nav>
+      </div>
+    </div>
+  <script src="https://code.jquery.com/jquery-3.4.1.min.js" integrity="sha256-CSXorXvZcTkaix6Yvo6HppcZGetbYMGWSFlBw8HfCJo=" crossorigin="anonymous"></script>
+  <script src="js/scripts.js"></script>
+</body>
+</html>

--- a/index-one-sidebar.html
+++ b/index-one-sidebar.html
@@ -1,0 +1,168 @@
+<!DOCTYPE html>
+<!-- Deploys to https://awalbhc.github.io/bhcc-refresh/ -->
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Ask for a repair to your council home | Brighton & Hove City Council</title>
+  <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:100,400,400i,600,600i,700,700i,900,900i" rel="stylesheet">
+  <link rel="stylesheet" href="normalize.css">
+  <link rel="stylesheet" href="style.css">
+  <style>
+    :root {
+      --gutter: 40px;
+    }
+  </style>
+</head>
+<body>
+  <header class="header overlay-wrapper" style="background-image: url(img/housing.jpg)">
+    <div class="wrapper">
+      <div class="header-top">
+        <a href="#"><img src="img/brighton-and-hove-city-council-logo.png" class="bhcc-logo" alt=""></a>
+      </div>
+      <div class="header-content">
+        <div class="header-title">Council housing</div>
+        <div class="header-subtitle">Apply for council housing, pay your rent, request a repair or report a problem</div>
+      </div>
+    </div>
+    <div class="overlay"></div>
+  </header>
+  <div class="breadcrumb">
+    <div class="wrapper">
+      <span class="breadcrumb-prefix">You are here:</span>
+      <ol class="breadcrumbs inline-list">
+        <li><a href="#">Home</a></li>
+        <li><a href="#">Housing</a></li>
+        <li><a href="#">Council housing</a></li>
+        <li>Ask for a repair to your council home</li>
+      </ol>
+    </div>
+  </div>
+  <div class="wrapper wrapper--no-gutter">
+    <main>
+      <div class="row">
+        <section class="page-content col-md-8">
+          <h1 class="page-title">Ask for a repair to your council home</h1>
+          <div class="page-subtitle">Ask us to repair your council home if it’s been damaged.</div>
+          <p>Before you ask us for a repair, make sure who’s responsible as there are some repairs you’ll need to carry out yourself.</p>
+          <p>You can request a repair online or, if your council home needs an emergency repair, call us on 0800 052 6140.</p>
+          <p>If the repair is for a suspected gas leak, please call the National Grid on 0800 111 999.</p>
+          <p>Repairs, maintenance and improvement services for council housing are now run directly by the council. Download our quick guide to the new repairs and maintenance service.</p>
+          <h2>How long does a repair take?</h2>
+          <p>When you ask us for a repair, the time it takes for us to start the work depends on the type of repair.</p>
+          <p>We’ll decide if your repair is:</p>
+          <ul>
+            <li>emergency, which we’ll start within 24 hours</li>
+            <li>routine, which we’ll start within 20 workings days</li>
+            <li>complex, which will take longer than 20 days to complete</li>
+          </ul>
+          <p>You can read more about types of repairs in our housing repairs handbook.</p>
+        </section>
+        <section class="sidebar col-md-4">
+          <h2>Services</h2>
+          <ul class="unstyled-list">
+            <li><a class="btn btn-success btn-next" href="#">Request a repair</a></li>
+            <li><a class="btn btn-success btn-next" href="#">Request an update to an existing repair</a></li>
+            <li><a class="btn btn-success btn-next" href="#">Give us feedback on a repair</a></li>
+          </ul>
+          <h2>More information</h2>
+          <ul class="unstyled-list sidebar-links">
+            <li><a href="#">Repairs, maintenance and improvement services from April 2020</a></li>
+            <li><a href="#">Your new repairs, maintenance and improvement service</a></li>
+          </ul>
+        </section>
+      </div>
+    </main>
+    <div class="row">
+      <div class="aside col-sm-12">
+        <nav class="service-navigation box">
+          <h2><a href="#">Home</a></h2>
+          <hr/>
+          <h3><a href="#">Housing</a></h3>
+          <hr/>
+          <ul class="service-navigation-level-1 unstyled-list">
+            <li class="accordion-active">
+              <h4><a class="accordion-expand" href="#">Council housing</a></h4>
+              <ul class="service-navigation-level-2 unstyled-list sidebar-links">
+                <li><a href="#">Apply to join the housing register</a></li>
+                <li><a href="#">Make a bid on Homemove</a></li>
+                <li><a href="#">Move out of council housing</a></li>
+                <li><a href="#">Tell us about a change of occupants in your council home</a></li>
+                <li><a href="#">Apply to move to a different council property</a></li>
+                <li><a href="#">Swap your council or housing association home</a></li>
+                <li><a href="#">Apply for the Transfer Incentive Scheme</a></li>
+                <li class="active"><a href="#">Ask for a repair to your council home</a></li>
+                <li><a href="#">Make an improvement to your council home</a></li>
+                <li><a href="#">Changes to your home</a></li>
+                <li><a href="#">Get help with gardening at your council home</a></li>
+                <li><a href="#">Get help with decorating your council home</a></li>
+              </ul>
+              <hr/>
+            </li>
+            <li>
+              <h4><a class="accordion-expand" href="#">Private housing</a></h4>
+              <ul class="service-navigation-level-2 unstyled-list sidebar-links">
+                <li><a href="#">Carry out work on your home</a></li>
+                <li><a href="#">Contact us about your private rented housing</a></li>
+                <li><a href="#">Changes to your home</a></li>
+                <li><a href="#">How to find a home to rent</a></li>
+                <li><a href="#">Get help to keep up with your rent</a></li>
+                <li><a href="#">Get help to buy a home</a></li>
+                <li><a href="#">Join the register to build your own home</a></li>
+                <li><a href="#">Privately rented home condition survey</a></li>
+                <li><a href="#">Contact us about a property you're renting out</a></li>
+                <li><a href="#">Rent out your property through the council</a></li>
+                <li><a href="#">Houses in Multiple Occupation</a></li>
+                <li><a href="#"> Fire safety advice for landlords</a></li>
+              </ul>
+              <hr/>
+            </li>
+            <li>
+              <h4><a class="accordion-expand"  href="#">Homelessness and living on the street</a></h4>
+              <ul class="service-navigation-level-2 unstyled-list sidebar-links">
+                <li><a href="#">Get help if you're at risk of becoming homeless</a></li>
+                <li><a href="#">Get help to keep up with your rent</a></li>
+                <li><a href="#">Duty to refer for homelessness</a></li>
+                <li><a href="#">Get help if you're living on the street</a></li>
+                <li><a href="#">How to help people living on the street</a></li>
+                <li><a href="#">How we help rough sleepers in the city</a></li>
+                <li><a href="#">Get shelter during the cold weather</a></li>
+                <li><a href="#">Privacy notice for evaluation of support</a></li>
+              </ul>
+              <hr/>
+            </li>
+            <li>
+              <h4><a class="accordion-expand"  class="expand" href="#">Housing supply</a></h4>
+              <ul class="service-navigation-level-2 unstyled-list sidebar-links">
+                <li><a href="#">New homes for council neighbourhoods</a></li>
+                <li><a href="#">New affordable homes in the city</a></li>
+                <li><a href="#">Sell your property back to the council</a></li>
+                <li><a href="#">Develop a housing site in the city</a></li>
+              </ul>
+              <hr/>
+            </li>
+            <li>
+              <h4><a class="accordion-expand"  href="#">Travelling communities</a></h4>
+              <ul class="service-navigation-level-2 unstyled-list sidebar-links">
+                <li><a href="#">Contact our Traveller Liaison team</a></li>
+                <li><a href="#">St Michael's Way Traveller site</a></li>
+              </ul>
+              <hr/>
+            </li>
+            <li>
+              <h4><a class="accordion-expand"  href="#">Housing strategy and data</a></h4>
+              <ul class="service-navigation-level-2 unstyled-list sidebar-links">
+                <li><a href="#">Policies and strategies in general housing</a></li>
+                <li><a href="#">Annual report to council tenants and leaseholders</a></li>
+              </ul>
+              <hr/>
+            </li>
+          </ul>
+        </nav>
+      </div>
+    </div>
+  <script src="https://code.jquery.com/jquery-3.4.1.min.js" integrity="sha256-CSXorXvZcTkaix6Yvo6HppcZGetbYMGWSFlBw8HfCJo=" crossorigin="anonymous"></script>
+  <script src="js/scripts.js"></script>
+</body>
+</html>

--- a/index-one-sidebar.html
+++ b/index-one-sidebar.html
@@ -11,6 +11,7 @@
   <link rel="stylesheet" href="style.css">
   <style>
     :root {
+      --base-font: 20px;
       --gutter: 40px;
     }
   </style>

--- a/index.html
+++ b/index.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<!-- Deploys to https://awalbhc.github.io/bhcc-refresh/ -->
 <html lang="en">
 <head>
   <meta charset="UTF-8">

--- a/style.css
+++ b/style.css
@@ -435,7 +435,11 @@ a.accordion-expand:after {
 .wrapper {
   max-width: 1240px;
   margin: 0px auto;
-  padding: 0px 20px;
+  padding: 0px var(--gutter);
+}
+
+.wrapper.wrapper--no-gutter {
+  padding: 0px 0px;
 }
 
 .header {

--- a/style.css
+++ b/style.css
@@ -95,6 +95,8 @@
   --clr-neutral-0: hsl(180, 0%, 0%);
   --clr-link: hsl(216, 93%, 52%);
   --clr-success: hsl(129, 78%, 30%);
+  --base-font: 20px;
+  --gutter: 20px;
 }
 
 /* Base */
@@ -105,15 +107,19 @@
   box-sizing: border-box;
 }
 
+html {
+  font-size: var(--base-font);
+}
+
 body {
   font-family: "Source Sans Pro", sans-serif;
   background-color: var(--clr-neutral-98);
   color: var(--clr-neutral-25);
-  font-size: 16px;
+  font-size: var(--base-font);
 }
 
 h1 {
-  font-size: 26px;
+  font-size: 1.625rem;
   font-weight: 600;
   line-height: 1;
   margin: 30px 0;
@@ -121,7 +127,7 @@ h1 {
 
 
 h2 {
-  font-size: 24px;
+  font-size: 1.5rem;
   font-weight: 600;
   line-height: 1;
   margin: 30px 0;
@@ -145,27 +151,36 @@ a {
 
 [class*="col-"] {
   width: 100%;
-  padding: 0px 20px; 
+  padding: 0px 20px;
 }
 
 .row {
   display: flex;
-  margin-left: -20px;
-  margin-right: -20px;
+  margin-left: calc(0 - var(--gutter));
+  margin-right: calc(0 - var(--gutter));
   flex-wrap: wrap;
 }
 
 .row::after {
   content: " ";
-  display: block; 
-  height: 0; 
+  display: block;
+  height: 0;
   clear: both;
 }
 
 @media only screen and (min-width: 768px) {
   [class*="col-"] {
-    float: left;
-    padding: 20px 20px; 
+    /* float: left; */
+    padding: var(--gutter) var(--gutter);
+  }
+
+  /* Remove any excess margins from first and last child so the line to container edges */
+  [class*="col-"] > :first-child {
+    margin-top: 0;
+  }
+
+  [class*="col-"] > :last-child {
+    margin-bottom: 0;
   }
 
   .col-sm-1 { max-width: 8.33%; flex: 0 0 8.33%; }
@@ -179,10 +194,9 @@ a {
   .col-sm-9 { max-width: 75%; flex: 0 0 75%; }
   .col-sm-10 { max-width: 83.33%; flex: 0 0 83.33%; }
   .col-sm-11 { max-width: 91.66%; flex: 0 0 91.66%; }
-  .col-sm-12 { max-width: 100%; flex: 0 0 100%; } 
+  .col-sm-12 { max-width: 100%; flex: 0 0 100%; }
 
   .mobile-reverse {
-    float: right;
     flex-direction: row-reverse;
   }
 }
@@ -190,10 +204,6 @@ a {
 
 
 @media only screen and (min-width: 1024px) {
-  [class*="col-"] {
-    float: left;
-    padding: 20px 20px; 
-  }
 
   .col-md-1 { max-width: 8.33%; flex: 0 0 8.33%; }
   .col-md-2 { max-width: 16.66%; flex: 0 0 16.66%; }
@@ -206,7 +216,7 @@ a {
   .col-md-9 { max-width: 75%; flex: 0 0 75%; }
   .col-md-10 { max-width: 83.33%; flex: 0 0 83.33%; }
   .col-md-11 { max-width: 91.66%; flex: 0 0 91.66%; }
-  .col-md-12 { max-width: 100%; flex: 0 0 100%; } 
+  .col-md-12 { max-width: 100%; flex: 0 0 100%; }
 
   .mobile-reverse {
     float: right;
@@ -233,7 +243,7 @@ a {
   padding: 15px 50px 15px 20px; ;
   text-decoration: none;
   border-radius: 4px;
-  font-size: 16px;
+  font-size: 1rem;
   line-height: 20px;
   font-weight: 600;
   color: var(--clr-neutral-100);
@@ -282,7 +292,7 @@ a {
   padding-right: 20px;
   text-decoration: none;
   font-weight: 600;
-  font-size: 14px;
+  font-size: 0.875rem;
   line-height: 18px;
 }
 
@@ -343,17 +353,17 @@ a {
 }
 
 .service-navigation h2 {
-  font-size: 16px;
+  font-size: 1rem;;
   line-height: 1;
 }
 
 .service-navigation h3 {
-  font-size: 16px;
+  font-size: 1rem;;
   line-height: 1;
 }
 
 .service-navigation h4 {
-  font-size: 14px;
+  font-size: 0.875rem;;
   line-height: 1;
 }
 
@@ -445,7 +455,7 @@ a.accordion-expand:after {
   margin-bottom: 20px;
   padding-bottom: 20px;
   font-family: "Sentinel", serif;
-  font-size: 30px;
+  font-size: 1.875rem;;
   line-height: 1;
   letter-spacing: .01em;
   font-weight: 700;
@@ -463,15 +473,15 @@ a.accordion-expand:after {
 
 .header-subtitle {
   max-width: 420px;
-  font-size: 18px;
-  line-height: 20px;
+  font-size: 1.125rem;;
+  line-height: 1.4;
 }
 
 .breadcrumb {
   background-color: var(--clr-neutral-94);
   color: var(--clr-neutral-5);
   padding: 10px 0px;
-  font-size: 14px;
+  font-size: 0.875rem;;
 }
 
 .breadcrumbs {
@@ -518,7 +528,7 @@ a.accordion-expand:after {
 
   .breadcrumbs li:nth-last-child(2) {
     display: inline;
-  } 
+  }
 }
 
 .page-content {
@@ -548,12 +558,12 @@ a.accordion-expand:after {
 }
 
 .page-subtitle {
-  font-size: 18px;
+  font-size: 1.125rem;;
   line-height: 20px;
   margin-bottom: 30px;
 }
 
 .sidebar h2 {
-  font-size: 20px;
+  font-size: 1.25rem;;
   color: var(--clr-neutral-34);
 }

--- a/style.css
+++ b/style.css
@@ -95,7 +95,7 @@
   --clr-neutral-0: hsl(180, 0%, 0%);
   --clr-link: hsl(216, 93%, 52%);
   --clr-success: hsl(129, 78%, 30%);
-  --base-font: 20px;
+  --base-font: 16px;
   --gutter: 20px;
 }
 


### PR DESCRIPTION
Not intended for merge, just a set of examples for problem solving some
potential layout issues.

These examples are
 
-  /index-larger-type.html for increased readability and easier to pass contrast tests.
-   /index-one-sidebar.html to move the services navigation to the bottom (May make adopting layout builder easier if the entire center part of the page was under comms control with us providing templates for layout builder)
-   /index-one-sidebar--alt-service-nav.html to fix above as doing the service nav full width looks strange 


